### PR TITLE
Add weights, model and custom config fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,14 @@ Can be `null` if the implementation is not framework specific.
 ### `model`
  - `source`: Language and framework specific implementation. This can either point to a local implementation:
   `<relative path to file>:<identifier of implementation within the source file>`
-
-  or the implementation in an available dependency:
-  <root-dependency>.<sub-dependency>.<identifier>
-
-  For example:
-  - ./my_function:MyImplementation
-  - core_library.some_module.some_function
-<!---
-java: <path-to-jar>:ClassName ?
--->
+  or the implementation in an available dependency: `<root-dependency>.<sub-dependency>.<identifier>`. 
+  
+    For example:
+      - `./my_function:MyImplementation`
+      - `core_library.some_module.some_function`
+      <!---
+      java: <path-to-jar>:ClassName ?
+      -->
 
  - `kwargs`: Keyword arguments for the implementation specified by [`source`](#source).
 
@@ -90,7 +88,6 @@ java: <path-to-jar>:ClassName ?
   ```
 
   Or you can drag and drop your file to this [online tool](https://bioimage.io/sha256.html) to generate it in your browser.
-
 
 
 <!---

--- a/README.md
+++ b/README.md
@@ -205,7 +205,27 @@ Specification of training process used to obtain the model weights. Must contain
       - `source`: Implementation of the optimizer. As usual, either relative path or importable from dependencies.
       - `kwargs`: keyword arguments for the optimizer
 
+### `config`
+A custom configuration field that can contain any other keys which are not defined above. It can be very specifc to a framework or specific tool. To avoid conflicted defintions, it is recommended to wrap configuration into a sub-field named with the specific framework or tool name. 
 
+For example:
+```yaml
+config:
+  # custom config for DeepImageJ, see https://github.com/bioimage-io/configuration/issues/23
+  deepimagej:
+    model_keys:
+    # In principle the tag "SERVING" is used in almost every tf model
+    model_tag: tf.saved_model.tag_constants.SERVING
+    # Signature definition to call the model. Again "SERVING" is the most general
+    signature_definition: tf.saved_model.signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY
+    test_information:  
+      input_size: [2048x2048] # Size of the input images  
+      output_size: [1264x1264 ]# Size of all the outputs  
+      device: cpu # Device used. In principle either cpu or GPU  
+      memory_peak: 257.7 Mb # Maximum memory consumed by the model in the device  
+      runtime: 78.8s # Time it took to run the model
+      pixel_size: [9.658E-4µmx9.658E-4µm] # Size of the pixels of the input
+```
 ## Reader Specification
 
 A reader entry in the bioimage.io model zoo is defined by a configuration file `<reader name>.reader.yaml`.

--- a/README.md
+++ b/README.md
@@ -60,28 +60,49 @@ What about `javascript`?
 The deep learning framework for which this object has been implemented. For now, we support `pytorch` and `tensorflow`.
 Can be `null` if the implementation is not framework specific.
 
-### `source`
+### `model`
 
-Language and framework specific implementation. This can either point to a local implementation:
-`<relative path to file>:<identifier of implementation within the source file>`
+- `source`
+  Language and framework specific implementation. This can either point to a local implementation:
+  `<relative path to file>:<identifier of implementation within the source file>`
 
-or the implementation in an available dependency:
-<root-dependency>.<sub-dependency>.<identifier>
+  or the implementation in an available dependency:
+  <root-dependency>.<sub-dependency>.<identifier>
 
-For example:
-- ./my_function:MyImplementation
-- core_library.some_module.some_function
+  For example:
+  - ./my_function:MyImplementation
+  - core_library.some_module.some_function
 <!---
 java: <path-to-jar>:ClassName ?
 -->
+- `sha256`
+  SHA256 checksum of the model file
 
-### `kwargs`
+  You can generate the SHA256 code for your model and weights by using for example, `hashlib` in Python, here is a codesnippet:
+  ```python
+  import hashlib
+  
+  # set your actual file name below
+  with open(filename,"rb") as f:
+      bytes = f.read() # read entire file as bytes
+      readable_hash = hashlib.sha256(bytes).hexdigest();
+      print(readable_hash)
+  ```
+
+  Or you can drag and drop your file to this [online tool](https://bioimage.io/sha256.html) to generate it in your browser.
+
+#### `kwargs`
 Keyword arguments for the implementation specified by [`source`](#source).
+
 
 <!---
 Do we want any positional arguments ? mandatory or optional?
 -->
 
+### `weights`
+A group of weights stored in key-value format, each weights definition contains the following fields:
+ - `source`: link to the model weight file. Preferably a zenode doi.
+ - `sha256`: SHA256 checksum of the model weight file specified by `source` (see `models` section above for how to generate SHA256 checksum)
 
 ## Transformation Specification
 
@@ -162,9 +183,7 @@ Force this to be explicit, or also allow any, identity, same?
 
 ### `prediction`
 Specification of prediction for the model. Must cotain the following keys:
-- `weights`: model weights to load for prediction, that were obtained by the training processs described in [training](#training).
-  `source`: link to the model weight file. Preferably a zenode doi.
-  `hash`: hash of hash of the model weight file specified by `source`
+- `weights`: the default model weights used for prediction, it must be a key defined in the root node `weights`.
 - `preprocess`:  list of transformations applied before the model input. Can be null if no preprocsssing is necessary. List entries must adhere to the [transformation entry](#transformation-entry) format.
 - `postprocess`: list of transformations applied after the model input. Can be null if no preprocessing is necessary. List entries must adhere to the [transformation entry] format.
 - `dependencies`: dependencies required to run prediction. See [transformation config](#transformation-specification).
@@ -182,6 +201,7 @@ Specification of training process used to obtain the model weights. Must contain
 - `source`: Implementation of the training process. Can either be a relative file and 
 - `kwargs`: Keyword arguments for the training implementation, that are not part of `setup`.
 - `setup`: The training set-up that is instantiated by the training function. It must contain the keys listed belows (for which we will provide parser functions.) It can consist additional keys, which needs to be parsed separately and may be used to extend the core library.
+    - `weights`: pretrained weights loaded before training starts, must be a key specified in the root node `weights`.
     - `reader`: specification of a [reader config](#reader-specification).
     - `sampler`: specification of a [sampler config](#sampler-specification).
     - `preprocess`: list of [transformation entries](#transformation-entry) that are applied before tensors are fed to the model. 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ The deep learning framework for which this object has been implemented. For now,
 Can be `null` if the implementation is not framework specific.
 
 ### `model`
-
-- `source`
-  Language and framework specific implementation. This can either point to a local implementation:
+ - `source`: Language and framework specific implementation. This can either point to a local implementation:
   `<relative path to file>:<identifier of implementation within the source file>`
 
   or the implementation in an available dependency:
@@ -75,8 +73,10 @@ Can be `null` if the implementation is not framework specific.
 <!---
 java: <path-to-jar>:ClassName ?
 -->
-- `sha256`
-  SHA256 checksum of the model file
+
+ - `kwargs`: Keyword arguments for the implementation specified by [`source`](#source).
+
+ - `sha256`: SHA256 checksum of the model file (for both serialized model file or source code).
 
   You can generate the SHA256 code for your model and weights by using for example, `hashlib` in Python, here is a codesnippet:
   ```python
@@ -91,8 +91,6 @@ java: <path-to-jar>:ClassName ?
 
   Or you can drag and drop your file to this [online tool](https://bioimage.io/sha256.html) to generate it in your browser.
 
-#### `kwargs`
-Keyword arguments for the implementation specified by [`source`](#source).
 
 
 <!---

--- a/README.md
+++ b/README.md
@@ -214,10 +214,10 @@ config:
   # custom config for DeepImageJ, see https://github.com/bioimage-io/configuration/issues/23
   deepimagej:
     model_keys:
-    # In principle the tag "SERVING" is used in almost every tf model
-    model_tag: tf.saved_model.tag_constants.SERVING
-    # Signature definition to call the model. Again "SERVING" is the most general
-    signature_definition: tf.saved_model.signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY
+      # In principle the tag "SERVING" is used in almost every tf model
+      model_tag: tf.saved_model.tag_constants.SERVING
+      # Signature definition to call the model. Again "SERVING" is the most general
+      signature_definition: tf.saved_model.signature_constants.DEFAULT_SERVING_SIGNATURE_DEF_KEY
     test_information:  
       input_size: [2048x2048] # Size of the input images  
       output_size: [1264x1264 ]# Size of all the outputs  

--- a/models/UNet2dExample.model.yaml
+++ b/models/UNet2dExample.model.yaml
@@ -20,8 +20,15 @@ format_version: 0.1.0
 language: python
 framework: pytorch
 
-source: unet2d.py::UNet2d
-kwargs: {input_channels: 1, output_channels: 1}
+model:
+    source: ./unet2d.py:UNet2d
+    kwargs: {input_channels: 1, output_channels: 1}
+
+weights:
+    my_weights:
+        # TODO how do we make clear that this is a doi? doi:.... ?
+        source: 10.5281/zenodo.3446812
+        sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
 
 test_input: my_test_input.npy  # language + extension defines memory representation
 test_output: my_test_output.npy
@@ -54,9 +61,7 @@ prediction:
           kwargs: {dtype: float32}
         - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/8959dab1236a72593613a5c89ea973c2f5612aea/specs/transformations/NormalizeZeroMeanUnitVariance.transformation.yaml
           kwargs: {apply_to: [0]}
-    weights:
-        source: https://zenodo.org/record/3446812/files/unet2d_weights.torch
-        hash: {md5: TODO}
+    weights: my_weights
     postprocess:
         - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/8959dab1236a72593613a5c89ea973c2f5612aea/specs/transformations/Sigmoid.transformation.yaml
         - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/8959dab1236a72593613a5c89ea973c2f5612aea/specs/transformations/EnsureNumpy.transformation.yaml


### PR DESCRIPTION
This PR implements the weights and model definition discuss in https://github.com/bioimage-io/configuration/issues/21, the following changes has been made:

 * add a model field in the root 
 * add a weights field in the root
 * change the weights in prediction to the key
 * add an optional weights field for training (as pretrained weights)
 * add a `config` field for storing custom config

Closes https://github.com/bioimage-io/configuration/issues/21.
Closes https://github.com/bioimage-io/configuration/issues/23.