### PR TITLE
Bump format version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The configurations are represented by a yaml file.
 
 To get a quick overview of the config file, see an example file [here](./models/UNet2dExample.model.yaml).
 
-## Current `format_version`: 0.1.0
+## Current `format_version`: 0.2.0
 
 ## Common keys
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Please use an image smaller than 500KB, aspect ratio width to height 2:1. The su
 
 ### `format_version`
 Version of this bioimage.io configuration specification. This is mandatory, and important for the consumer software to verify before parsing the fields.
+
 The recommended behavior for the implementation is to keep backward compatibility, and throw error if the model yaml is in an unsupported format version.
 
 ### `language`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The model zoo specification contains configuration definitions for the following
 
 The configurations are represented by a yaml file.
 
+To get a quick overview of the config file, see an example file [here](./models/UNet2dExample.model.yaml).
+
+## Current `format_version`: 0.1.0
 
 ## Common keys
 
@@ -46,7 +49,8 @@ A list of cover images provided by either a relative path to the model folder, o
 Please use an image smaller than 500KB, aspect ratio width to height 2:1. The supported image formats are: `jpg`, `png`, `gif`.
 
 ### `format_version`
-Version of this bioimage.io configuration specification.
+Version of this bioimage.io configuration specification. This is mandatory, and important for the consumer software to verify before parsing the fields.
+The recommended behavior for the implementation is to keep backward compatibility, and throw error if the model yaml is in an unsupported format version.
 
 ### `language`
 
@@ -87,7 +91,7 @@ Can be `null` if the implementation is not framework specific.
       print(readable_hash)
   ```
 
-  Or you can drag and drop your file to this [online tool](https://bioimage.io/sha256.html) to generate it in your browser.
+  Or you can drag and drop your file to this [online tool](http://emn178.github.io/online-tools/sha256_checksum.html) to generate it in your browser.
 
 
 <!---
@@ -95,8 +99,13 @@ Do we want any positional arguments ? mandatory or optional?
 -->
 
 ### `weights`
-A group of weights stored in key-value format, each weights definition contains the following fields:
- - `source`: link to the model weight file. Preferably a zenode doi.
+A list of weights, each weights definition contains the following fields:
+ - `id`: an unique id which will be used to refer the weights, e.g. in `prediction` or `training`.
+ - `name`: the name of the weights for display, it should be a human-friendly name in title case
+ - `description`: description about the weights, it is recommended to describe the how the weights is trained, and what's the dataset used for training.
+ - `authors`: a list of authors. This field is optional, only required if the authors are different from the model.
+ - `covers`: a list of cover images. This is used for showing how the inputs and outputs looks like with this weights file.
+ - `source`: link to the weights file. Preferably an url to the weights file.
  - `sha256`: SHA256 checksum of the model weight file specified by `source` (see `models` section above for how to generate SHA256 checksum)
 
 ## Transformation Specification

--- a/models/UNet2dExample.model.yaml
+++ b/models/UNet2dExample.model.yaml
@@ -25,10 +25,25 @@ model:
     kwargs: {input_channels: 1, output_channels: 1}
 
 weights:
-    my_weights:
-        # TODO how do we make clear that this is a doi? doi:.... ?
-        source: 10.5281/zenodo.3446812
-        sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
+    - id: default
+      name: Default Weights
+      # TODO how do we make clear that this is a doi? doi:.... ?
+      source: 10.5281/zenodo.3446812
+      sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
+      timestamp: 2019-12-11T12:22:32.11
+      authors: ["author1", "author2"]
+      covers: []
+      description: "Weights from DataScienceBowl"
+      # These should be different they are not
+    - id: my_other_weights
+      name: My Other Weights
+      source: 10.5281/zenodo.3446812
+      sha256: e4d3885bccbe41cbf6c1d825f3cd2b707c7021ead5593156007e407a16b27cf2
+      parent: default
+      timestamp: 2019-12-14T21:59:43.10
+      authors: ["author2"]
+      covers: []
+      description: "Fine tuned weights based on DataScienceBowl"
 
 test_input: my_test_input.npy  # language + extension defines memory representation
 test_output: my_test_output.npy
@@ -61,7 +76,7 @@ prediction:
           kwargs: {dtype: float32}
         - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/8959dab1236a72593613a5c89ea973c2f5612aea/specs/transformations/NormalizeZeroMeanUnitVariance.transformation.yaml
           kwargs: {apply_to: [0]}
-    weights: my_weights
+    weights: default
     postprocess:
         - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/8959dab1236a72593613a5c89ea973c2f5612aea/specs/transformations/Sigmoid.transformation.yaml
         - spec: https://github.com/bioimage-io/pytorch-bioimage-io/blob/8959dab1236a72593613a5c89ea973c2f5612aea/specs/transformations/EnsureNumpy.transformation.yaml

--- a/models/UNet2dExample.model.yaml
+++ b/models/UNet2dExample.model.yaml
@@ -16,7 +16,7 @@ documentation: ./unet2d.md
 tags: [unet2d, pytorch, nucleus-segmentation]
 covers: []
 
-format_version: 0.1.0
+format_version: 0.2.0
 language: python
 framework: pytorch
 


### PR DESCRIPTION
We forgot to bump the format version when changing the specification. This is a patch PR for that, I bumped the version to `0.2.0`.

However, following Semantic Versioning 2.0.0 https://semver.org/ it seems we should bump the version to 1.0.0 since we are breaking the API, but I hesitate to do that because we are not ready to release it as 1.0.0 yet.

