### PR TITLE
Synchronize the example file with the config description

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ A list of weights, each weights definition contains the following fields:
     - `requires_model_source` boolean; defines if this weight entry can be loaded independently of the model source (it must contain the model architecture in this case) or not.
     - `test_inputs` relative file path to test inputs. `language` and the file extension define its memory representation.
     The test inputs are always stored as a list of tensors as described in `inputs`.
-    - `test_output` relative file path to test outputs. `language` and the file extension define its memory representation.
+    - `test_outputs` relative file path to test outputs. `language` and the file extension define its memory representation.
     The test outputs are always stored as a list of tensors as described in `outputs`.
     - `documentation` relative path to file with additional documentation in markdown.
     - `attachments` text keys and URI values to additional, relevant files.

--- a/models/UNet2dExample.model.yaml
+++ b/models/UNet2dExample.model.yaml
@@ -39,10 +39,6 @@ outputs:
         scale: [1, 1, 1, 1]
         offset: [0, 0, 0, 0]
 
-test_input: my_test_input.npy  # language + extension defines memory representation
-test_output: my_test_output.npy
-
-
 model:
     source: ./unet2d.py:UNet2d
     kwargs: {input_channels: 1, output_channels: 1}
@@ -62,6 +58,8 @@ weights:
       covers: []
       description: "Weights from DataScienceBowl"
       # These should be different they are not
+      test_inputs: my_default_test_input.npy  # language + extension defines memory representation
+      test_outputs: my_default_test_output.npy
     - id: my_other_weights
       name: My Other Weights
       source: 10.5281/zenodo.3446812
@@ -71,6 +69,8 @@ weights:
       authors: ["author2"]
       covers: []
       description: "Fine tuned weights based on DataScienceBowl"
+      test_inputs: my_other_test_input.npy  # language + extension defines memory representation
+      test_outputs: my_other_test_output.npy
 
 
 config: # optional

--- a/models/UNet2dExample.model.yaml
+++ b/models/UNet2dExample.model.yaml
@@ -1,8 +1,6 @@
 # TODO physical scale of the data
 # TODO discuss the depenendencies more closely
-language: python
-framework: pytorch
-format_version: 0.2.0
+format_version: 0.3.0
 
 name: UNet2dExample
 description: A 2d U-Net.
@@ -50,6 +48,8 @@ model:
     kwargs: {input_channels: 1, output_channels: 1}
     covers: []
     dependencies: conda:./environment.yaml
+    language: python
+    framework: pytorch
 
 weights:
     - id: default


### PR DESCRIPTION
A typo (I guess) in README.md:
- In `weights`, change `test_output` to `test_outputs`

Changes in `UNet2dExample.model.yaml` to agree with the description of the configuration. 