### PR TITLE
Add execution_model field

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ For example:
         - `sha256` SHA256 checksum of the model weight file specified by `source` (see `models` section above for how to generate SHA256 checksum)
         - `[attachments]` weight specific attachments that will be included when generating the model package.
 
-- `[execution_model]` Custom mode for running prediction with this model. For more complex prediction procedures like test time data augmentation that cannot be expressed in the current model configuration. The different execution models should be listed in [supported_formats_and_operations.md#Execution Model](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#execution_model)
-  - `name` the name of the execution model
-  - `[kwargs]` keyword arguments for this execution model
+- `[run_mode]` Custom run mode for this model: for more complex prediction procedures like test time data augmentation that currently cannot be expressed in the specification. The different run modes should be listed in [supported_formats_and_operations.md#Run Modes](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#run modes)
+  - `name` the name of the `run_mode`
+  - `[kwargs]` keyword arguments for this `run_mode`
  
 - `[config]`
 A custom configuration field that can contain any other keys which are not defined above. It can be very specifc to a framework or specific tool. To avoid conflicted defintions, it is recommended to wrap configuration into a sub-field named with the specific framework or tool name. 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ For example:
         - `source` link to the weights file. Preferably an url to the weights file.
         - `sha256` SHA256 checksum of the model weight file specified by `source` (see `models` section above for how to generate SHA256 checksum)
         - `[attachments]` weight specific attachments that will be included when generating the model package.
+
+- `[execution_model]` Custom mode for running prediction with this model. For more complex prediction procedures like test time data augmentation that cannot be expressed in the current model configuration. The different execution models should be listed in [supported_formats_and_operations.md#Execution Model](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#execution_model)
+  - `name` the name of the execution model
+  - `[kwargs]` keyword arguments for this execution model
  
 - `[config]`
 A custom configuration field that can contain any other keys which are not defined above. It can be very specifc to a framework or specific tool. To avoid conflicted defintions, it is recommended to wrap configuration into a sub-field named with the specific framework or tool name. 

--- a/supported_formats_and_operations.md
+++ b/supported_formats_and_operations.md
@@ -109,3 +109,11 @@ Which consumer supports which postprocessing operation?
 |  `scale_mean_variance`| no      | ?          | yes  |
 |  `scale_min_max`      | no      | ?          | yes  |
 |  `scale_linear`       | no      | ?          | ?    |
+
+
+# Run Modes
+
+Custom run modes to enable more complex prediction procedures.
+
+
+## Consumers


### PR DESCRIPTION
As discussed in the meeting, this adds the `execution_model` field to specify custom prediction procedutes.
Let me know if you agree with the description here and if we want to stick wit the name or still change it.
(I am just putting a veto on `runner`, because it's ambiguous with our other usage of this term ;))

@oeway @frauzufall @fjug @esgomezm @FynnBe @m-novikov 