### PR TITLE
Shape description and authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The person(s) that have packaged and uploaded this model. Only needs to be speci
 
 - [`parent`] Parent model from which this model has been derived, e.g. by finetuning the weights of this model on a different dataset.
   - `uri` Url of another model available on bioimage.io or path to a local model in the bioimage.io specification. If it is a url, it needs to be a github url linking to the page containing the model (NOT the raw file). 
-  - `hash` hash of the weights of the parent models
+  - `sha256` hash of the weights of the parent model.
 
 - `inputs`
 Describes the input tensors expected by this model.
@@ -68,8 +68,8 @@ Must be a list of *tensor specification keys*.
 
   *tensor specification keys*:
   - `name` tensor name
-  - `data_type` data type (e.g. float32)
-  - `data_range` tuple of (minimum, maximum), e.g. [0, 1]
+  - `data_type` the data type of this tensor. For inputs, only `float32` is allowed and the consumer software needs to ensure that the correct data type is passed here. For outputs can be any of `float32, float64, (u)int8, (u)int16, (u)int32, (u)int64`. The data flow in bioimage.io models is explained [in this diagram.](https://docs.google.com/drawings/d/1FTw8-Rn6a6nXdkZ_SkMumtcjvur9mtIhRqLwnKqZNHM/edit).
+  - `[data_range]` tuple `(minimum, maximum)` specifying the allowed range of the data in this tensor. If not specified, the full data range that can be expressed in `data_type` is allowed.
   - `axes` string of axes identifying characters from: btczyx. Same length and order as the axes in `shape`.
   - `shape` specification of tensor shape. It can be specified in three diffeent ways:
     1. as exact shape with same length as `axes`, e.g. `shape: [1, 512, 512, 1]`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Relative path to file with additional documentation in markdown.
 - `attachments`
 Dictionary of text keys and URI values to additional, relevant files.
 
+- [`pacakged_by`]
+The person(s) that have packaged and uploaded this model. Only needs to be specified if different from `authors` in the root weights`, see `weights` for more details.
+
+- [`parent`] Parent model from which this model has been derived, e.g. by finetuning the weights of this model on a different dataset.
+  - `id` Url of another model available on bioimage.io or path to a local model in the bioimage.io specification. In addition to the 
+  - `hash` hash of the weights of the parent models
+
 - `inputs`
 Describes the input tensors expected by this model.
 Must be a list of *tensor specification keys*.
@@ -144,7 +151,8 @@ For example:
 
 - `weights` The weights for this model. Weights can be given for different formats, but should otherwise be equivalent. The available weight formats determine which consumers can use this model.
    - `weight_format` Format of this set of weights. Weight formats can define additional (optional or required) fields. See [supported_formats_and_operations.md#Weight Format](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#weight_format)
-        - `[authors]` a list of authors.
+        - `authors` a list of authors. If this is the root weight (it does not have a `parent` field): the person(s) that have trained this model. If this is a child wieght (it has a `parent` field): the person(s) who have converted the weights to this format.
+        - [`parent`]* the source weights used as input for converting the weights to this format. For example, if the weights were converted from the format `pytorch_state_dict` to `pytorch_script`, the parent is `pytorch_state_dict`. All weight entries except one (the initial set of weights resulting from training the model), need to have this field.
         - `source` link to the weights file. Preferably an url to the weights file.
         - `sha256` SHA256 checksum of the model weight file specified by `source` (see `sha256` section for how to generate the checksum)
         - `[attachments]` weight specific attachments that will be included when generating the model package.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Must be a list of *tensor specification keys*.
        - `reference_input` name of the reference input tensor
        - `scale` list of factors 'output_pix/input_pix' for each dimension
        - `offset` position of origin wrt to input 
-       - `halo` the halo to crop from the output tensor (for example to crop away boundary efects or for tiling). The halo should be croped from both size, i.e. `shape_after_crop = shape - 2 * halo`.
+       - `halo` the halo to crop from the output tensor (for example to crop away boundary efects or for tiling). The halo should be croped from both size, i.e. `shape_after_crop = shape - 2 * halo`. The `halo` is not cropped by the bioimage.io model, but is left to be cropped by the consumer software. See `offset` for a 'halo' that is cropped by the model.
   - `[preprocessing]` (only for input) list of transformations describing how this input should be preprocessed. Each entry has these keys:
     - `name` name of preprocessing (see [supported_formats_and_operations.md#preprocessing](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#preprocessing) for valid names).
     - `[kwargs]` key word arguments for `preprocessing`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Must be a list of *tensor specification keys*.
        - `min` the minimum input shape with same length as `axes`
        - `step` the minimum shape change with same length as `axes`
     3. (only for output) in reference to the shape of an input tensor.\
-       The shape of the output tensor is `shape = shape(input_tensor) * scale + offset`. Specified by the following fields:
+       The shape of the output tensor is `shape = shape(input_tensor) * scale + 2 * offset`. Specified by the following fields:
        - `reference_input` name of the reference input tensor
        - `scale` list of factors 'output_pix/input_pix' for each dimension
        - `offset` position of origin wrt to input 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Dictionary of text keys and URI values to additional, relevant files.
 The person(s) that have packaged and uploaded this model. Only needs to be specified if different from `authors` in the root weights`, see `weights` for more details.
 
 - [`parent`] Parent model from which this model has been derived, e.g. by finetuning the weights of this model on a different dataset.
-  - `id` Url of another model available on bioimage.io or path to a local model in the bioimage.io specification. In addition to the 
+  - `uri` Url of another model available on bioimage.io or path to a local model in the bioimage.io specification. If it is a url, it needs to be a github url linking to the page containing the model (NOT the raw file). 
   - `hash` hash of the weights of the parent models
 
 - `inputs`

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Relative path to file with additional documentation in markdown.
 - `attachments`
 Dictionary of text keys and URI values to additional, relevant files.
 
-- [`pacakged_by`]
+- [`packaged_by`]
 The person(s) that have packaged and uploaded this model. Only needs to be specified if different from `authors` in the root weights`, see `weights` for more details.
 
 - [`parent`] Parent model from which this model has been derived, e.g. by finetuning the weights of this model on a different dataset.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Dictionary of text keys and URI values to additional, relevant files.
 - [`packaged_by`]
 The person(s) that have packaged and uploaded this model. Only needs to be specified if different from `authors` in the root weights`, see `weights` for more details.
 
-- [`parent`] Parent model from which this model has been derived, e.g. by finetuning the weights of this model on a different dataset.
+- [`parent`] Parent model from which the trained weights of this model have been derived, e.g. by finetuning the weights of this model on a different dataset. For format changes of the same trained model checkpoint, see `weights`.
   - `uri` Url of another model available on bioimage.io or path to a local model in the bioimage.io specification. If it is a url, it needs to be a github url linking to the page containing the model (NOT the raw file). 
   - `sha256` hash of the weights of the parent model.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Must be a list of *tensor specification keys*.
        - `reference_input` name of the reference input tensor
        - `scale` list of factors 'output_pix/input_pix' for each dimension
        - `offset` position of origin wrt to input 
-       - `halo` the halo to crop from the output tensor (for example to crop away boundary efects or for tiling). The halo should be croped from both size, i.e. `shape_after_crop = shape - 2 * halo`. The `halo` is not cropped by the bioimage.io model, but is left to be cropped by the consumer software. See `offset` for a 'halo' that is cropped by the model.
+       - `halo` the halo to crop from the output tensor (for example to crop away boundary efects or for tiling). The halo should be croped from both sides, i.e. `shape_after_crop = shape - 2 * halo`. The `halo` is not cropped by the bioimage.io model, but is left to be cropped by the consumer software. Use `offset` if the model output itself is cropped.
   - `[preprocessing]` (only for input) list of transformations describing how this input should be preprocessed. Each entry has these keys:
     - `name` name of preprocessing (see [supported_formats_and_operations.md#preprocessing](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#preprocessing) for valid names).
     - `[kwargs]` key word arguments for `preprocessing`.

--- a/supported_formats_and_operations.md
+++ b/supported_formats_and_operations.md
@@ -97,7 +97,7 @@ The supported postprocessing operations.
     - `max` (if `mode == fixed`) the fixed max value
     - `reference_input` name of the input tensor to use as reference
   - `reference_implementation`
-- `scale_linear` scale the tensor with a fixed multiplicative and additive factor, sae as in [preprocessing](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#preprocessing).
+- `scale_linear` scale the tensor with a fixed multiplicative and additive factor, same as in [preprocessing](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#preprocessing).
 
 ## Consumers
 

--- a/supported_formats_and_operations.md
+++ b/supported_formats_and_operations.md
@@ -47,6 +47,7 @@ The supported preprocessing operations.
   - `reference_implementation`
 - `scale_min_max` normalize the tensor to range 0, 1
   - `kwargs`
+    - `mode` can be one of `per_sample` (min and max are computed for each sample individually), `per_dataset` (min and max are computed for the entire dataset)
     - `axes` the subset of axes to normalize jointly. For example `xy` to normalize the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
   - `reference_implementation`
 - `zero_mean_unit_variance` normalize the tensor to have zero mean and unit variance

--- a/supported_formats_and_operations.md
+++ b/supported_formats_and_operations.md
@@ -32,10 +32,6 @@ The supported preprocessing operations.
     - `min` minimum value for clipping
     - `max` maximum value for clipping
   - `reference_implementation`
-- `min_max` normalize the tensor to range 0, 1
-  - `kwargs`
-    - `axes` the subset of axes to normalize jointly. For example `xy` to normalize the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
-  - `reference_implementation`
 - `percentile` normalize the tensor with percentile normalization
   - `kwargs`
     - `mode` can be one of `per_sample` (percentiles are computed for each sample individually), `per_dataset` (percentiles are computed for the entire dataset)
@@ -48,6 +44,10 @@ The supported preprocessing operations.
     - `gain` multiplicative factor
     - `offset` additive factor
     - `axes` the subset of axes to scale jointly. For example `xy` to scale the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
+  - `reference_implementation`
+- `scale_min_max` normalize the tensor to range 0, 1
+  - `kwargs`
+    - `axes` the subset of axes to normalize jointly. For example `xy` to normalize the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
   - `reference_implementation`
 - `zero_mean_unit_variance` normalize the tensor to have zero mean and unit variance
   - `kwargs`

--- a/supported_formats_and_operations.md
+++ b/supported_formats_and_operations.md
@@ -37,7 +37,7 @@ The supported preprocessing operations.
     - `mode` can be one of `per_sample` (percentiles are computed for each sample individually), `per_dataset` (percentiles are computed for the entire dataset)
     - `axes` the subset of axes to normalize jointly. For example `xy` to normalize the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
     - `min_percentile` the lower percentile used for normalization, in range 0 to 100.
-    - `max_percentile` the upper percentile used for normalization, in range 0 to 100. Has to be bigger than `upper_percentile`.
+    - `max_percentile` the upper percentile used for normalization, in range (1, 100]. Has to be bigger than `upper_percentile`. Note: We do not allow values <=1 to avoid mistakenly specifying the percentiles in [0,1]
   - `reference_implementaion`
 - `scale_linear` scale the tensor with a fixed multiplicative and additive factor
   - `kwargs`

--- a/supported_formats_and_operations.md
+++ b/supported_formats_and_operations.md
@@ -43,6 +43,12 @@ The supported preprocessing operations.
     - `min_percentile` the lower percentile used for normalization, in range 0 to 100.
     - `max_percentile` the upper percentile used for normalization, in range 0 to 100. Has to be bigger than `upper_percentile`.
   - `reference_implementaion`
+- `scale_linear` scale the tensor with a fixed multiplicative and additive factor
+  - `kwargs`
+    - `gain` multiplicative factor
+    - `offset` additive factor
+    - `axes` the subset of axes to scale jointly. For example `xy` to scale the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
+  - `reference_implementation`
 - `zero_mean_unit_variance` normalize the tensor to have zero mean and unit variance
   - `kwargs`
     - `mode` can be one of `fixed` (fixed values for mean and variance), `per_sample` (mean and variance are computed for each sample individually), `per_dataset` (mean and variance are computed for the entire dataset)
@@ -61,6 +67,7 @@ Which consumer supports which preprocessing operation?
 |  `clip`                    | ?       | ?          | ?    | 
 |  `min_max`                 | ?       | ?          | ?    |
 |  `percentile`              | ?       | ?          | ?    |
+| `scale_linear`             | ?       | ?          | ?    |
 |  `zero_mean_unit_variance` | yes     | ?          | ?    |
 
 
@@ -90,12 +97,7 @@ The supported postprocessing operations.
     - `max` (if `mode == fixed`) the fixed max value
     - `reference_input` name of the input tensor to use as reference
   - `reference_implementation`
-- `scale_linear` scale the tensor with a fixed multiplicative and additive factor
-  - `kwargs`
-    - `gain` multiplicative factor
-    - `offset` additive factor
-    - `axes` the subset of axes to scale jointly. For example `xy` to scale the two image axes for 2d data jointly. The batch axis (`b`) is not valid here.
-  - `reference_implementation`
+- `scale_linear` scale the tensor with a fixed multiplicative and additive factor, sae as in [preprocessing](https://github.com/bioimage-io/configuration/blob/master/supported_formats_and_operations.md#preprocessing).
 
 ## Consumers
 


### PR DESCRIPTION
This PR includes:
- extension of the shape description based on the work by @esgomezm in #54 
- update to the `author` fields and introduction of the `parent` fields

Please have a look if this reflects what we agreed upon in the meeting today and feel free to suggest changes, @esgomezm @oeway @frauzufall.